### PR TITLE
Add reference link to OAuth1 spec

### DIFF
--- a/versions/3.0.md
+++ b/versions/3.0.md
@@ -3369,7 +3369,7 @@ animals:
 #### <a name="securitySchemeObject"></a>Security Scheme Object
 
 Allows the definition of a security scheme that can be used by the operations.
-Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter), OAuth2's common flows (implicit, password, application and access code) and OAuth1.
+Supported schemes are HTTP authentication, an API key (either as a header or as a query parameter), OAuth2's common flows (implicit, password, application and access code) and OAuth1 as defined in [RFC5849](https://tools.ietf.org/html/rfc5849).
 
 ##### Fixed Fields
 Field Name | Type | Validity | Description


### PR DESCRIPTION
Went with adding just the link to RFC5849 which is functionally identical with OAuth 1.0 Core Revision A (OAuth 1.0a). [OAuth WRAP](http://wiki.oauth.net/w/page/12238537/OAuth%20WRAP) looks like a half-way house to OAuth 2.0 which didn't really gain traction.

Some APIs may only provide pre-RFC5849 versions of OAuth1, but I think it would get messy to claim the OAS supports deprecated versions of standards.